### PR TITLE
Byttet til et navn som er mindre knyttet til DittNAV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CircleCI](https://circleci.com/gh/navikt/dittnav-event-schemas.svg?style=svg)](https://circleci.com/gh/navikt/dittnav-event-schemas)
+[![CircleCI](https://circleci.com/gh/navikt/brukernotifikasjon-schemas.svg?style=svg)](https://circleci.com/gh/navikt/brukernotifikasjon-schemas)
 
-[![Published on Maven](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/no/nav/personbruker/dittnav/event-schemas/maven-metadata.xml.svg)](http://central.maven.org/maven2/no/nav/personbruker/dittnav/event-schemas/)
+[![Published on Maven](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/no/nav/brukernotifikasjon-schemas/maven-metadata.xml.svg)](http://central.maven.org/maven2/no/nav/brukernotifikasjon-schemas/)
 
-# DittNAV event schemas
+# Brukernotifikasjon-schemas
 
-Skjemaer for DittNAV sine Kafka-topics, og brukes for å sende notifikasjoner til DittNAV som kafka-events.
+Skjemaer for brukernotifikasjon-Kafka-topic-ene som bla DittNAV bruker for å vise notifikasjoner til sluttbrukere.
 
 # Kom i gang
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>no.nav.personbruker.dittnav</groupId>
-    <artifactId>event-schemas</artifactId>
+    <groupId>no.nav</groupId>
+    <artifactId>brukernotifikasjon-schemas</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>dittnav-event-schemas</name>
+    <name>brukernotifikasjon-schemas</name>
     <description>Definitions for events in Ditt NAV</description>
-    <url>https://github.com/navikt/dittnav-event-schemas</url>
+    <url>https://github.com/navikt/brukernotifikasjon-schemas</url>
 
     <licenses>
         <license>
@@ -27,9 +27,9 @@
     </developers>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:navikt/dittnav-event-schemas.git</developerConnection>
-        <connection>scm:git:git@github.com:navikt/dittnav-event-schemas.git</connection>
-        <url>https://github.com/navikt/dittnav-event-schemas</url>
+        <developerConnection>scm:git:git@github.com:navikt/brukernotifikasjon-schemas.git</developerConnection>
+        <connection>scm:git:git@github.com:navikt/brukernotifikasjon-schemas.git</connection>
+        <url>https://github.com/navikt/brukernotifikasjon-schemas</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/src/main/avro/informasjon.avsc
+++ b/src/main/avro/informasjon.avsc
@@ -1,6 +1,6 @@
 {
     "type": "record",
-    "namespace": "no.nav.personbruker.dittnav.event.schemas",
+    "namespace": "no.nav.brukernotifikasjon.schemas",
     "name": "Informasjon",
     "fields": [
         {

--- a/src/main/avro/melding.avsc
+++ b/src/main/avro/melding.avsc
@@ -1,6 +1,6 @@
 {
     "type": "record",
-    "namespace": "no.nav.personbruker.dittnav.event.schemas",
+    "namespace": "no.nav.brukernotifikasjon.schemas",
     "name": "Melding",
     "fields": [
         {

--- a/src/main/avro/oppgave.avsc
+++ b/src/main/avro/oppgave.avsc
@@ -1,6 +1,6 @@
 {
     "type": "record",
-    "namespace": "no.nav.personbruker.dittnav.event.schemas",
+    "namespace": "no.nav.brukernotifikasjon.schemas",
     "name": "Oppgave",
     "fields": [
         {


### PR DESCRIPTION
Endret navn på prosjektet og pakkenavn for å gjøre det tydeligere at vi ønsker at flere enn DittNAV skal kunne ta i bruk eventene.