### PR TITLE
Bytter navn på et par felter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @navikt/personbruker
+* @navikt/dittnav

--- a/src/main/avro/done.avsc
+++ b/src/main/avro/done.avsc
@@ -13,7 +13,7 @@
             "logicalType": "timestamp-millis"
         },
         {
-            "name": "aktorId",
+            "name": "fodselsnummer",
             "type": "string"
         },
         {
@@ -21,7 +21,7 @@
             "type": "string"
         },
         {
-            "name": "dokumentId",
+            "name": "grupperingsId",
             "type": "string"
         }
     ]

--- a/src/main/avro/informasjon.avsc
+++ b/src/main/avro/informasjon.avsc
@@ -13,7 +13,7 @@
             "logicalType": "timestamp-millis"
         },
         {
-            "name": "aktorId",
+            "name": "fodselsnummer",
             "type": "string"
         },
         {
@@ -21,7 +21,7 @@
             "type": "string"
         },
         {
-            "name": "dokumentId",
+            "name": "grupperingsId",
             "type": "string"
         },
         {

--- a/src/main/avro/innboks.avsc
+++ b/src/main/avro/innboks.avsc
@@ -13,7 +13,7 @@
             "logicalType": "timestamp-millis"
         },
         {
-            "name": "aktorId",
+            "name": "fodselsnummer",
             "type": "string"
         },
         {
@@ -21,7 +21,7 @@
             "type": "string"
         },
         {
-            "name": "dokumentId",
+            "name": "grupperingsId",
             "type": "string"
         },
         {

--- a/src/main/avro/oppgave.avsc
+++ b/src/main/avro/oppgave.avsc
@@ -13,7 +13,7 @@
             "logicalType": "timestamp-millis"
         },
         {
-            "name": "aktorId",
+            "name": "fodselsnummer",
             "type": "string"
         },
         {
@@ -21,7 +21,7 @@
             "type": "string"
         },
         {
-            "name": "dokumentId",
+            "name": "grupperingsId",
             "type": "string"
         },
         {


### PR DESCRIPTION
Bytter navn på to felter for at det skal være mest mulig entydig hva som forventes som innhold i feltene.

* Team Registre anbefaler at fødselsnummer/D-nummer brukes fram for aktørId.
* Feltet dokumentId endres til grupperingsId, fordi dette er et felt som er ment for å gruppere eventer. F.eks. et dokumentnummer, saksnummer etc.