### PR TITLE
Legger til test på at eksternVarsling settes til default false.

### DIFF
--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedAvroTest.java
@@ -1,0 +1,45 @@
+package no.nav.brukernotifikasjon.schemas.builders;
+
+import no.nav.brukernotifikasjon.schemas.Beskjed;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BeskjedAvroTest {
+
+    private int expectedSikkerhetsnivaa = 4;
+    private boolean expectedEksternVarsling = false;
+
+    @Test
+    void skalSetteDefaultverdiForSikkerhetsnivaa() {
+        Beskjed beskjed = getBeskjedWithDefaultValues();
+        assertThat(beskjed.getSikkerhetsnivaa(), is(expectedSikkerhetsnivaa));
+    }
+
+    @Test
+    void skalSetteDefaultverdiForEksternVarsling() {
+        Beskjed beskjed = getBeskjedWithDefaultValues();
+        assertThat(beskjed.getEksternVarsling(), is(expectedEksternVarsling));
+    }
+
+    @Test
+    void skalSetteNullSomDefaultverdiForSynligFremTil() {
+        Beskjed beskjed = getBeskjedWithDefaultValues();
+        assertThat(beskjed.getSynligFremTil(), is(nullValue()));
+    }
+
+    private Beskjed getBeskjedWithDefaultValues() {
+        return Beskjed.newBuilder()
+                .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
+                .setFodselsnummer("12345678901")
+                .setGrupperingsId("3456789123456")
+                .setTekst("Dette er informasjon du må lese")
+                .setLink("https://gyldig.url")
+                .build();
+    }
+}

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedBuilderTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedBuilderTest.java
@@ -29,6 +29,7 @@ public class BeskjedBuilderTest {
     private String expectedTekst;
     private LocalDateTime expectedTidspunkt;
     private LocalDateTime expectedSynligFremTil;
+    private Boolean expectedEksternVarsling;
 
     @BeforeAll
     void setUp() throws MalformedURLException {
@@ -39,6 +40,7 @@ public class BeskjedBuilderTest {
         expectedTekst = "Dette er informasjon du må lese";
         expectedTidspunkt = LocalDateTime.now(ZoneId.of("UTC"));
         expectedSynligFremTil = expectedTidspunkt.plusDays(2);
+        expectedEksternVarsling = false;
     }
 
     @Test
@@ -55,6 +57,7 @@ public class BeskjedBuilderTest {
         assertThat(beskjed.getTidspunkt(), is(expectedTidspunktAsUtcLong));
         long expectedSynligFremTilAsUtcLong = expectedSynligFremTil.toInstant(ZoneOffset.UTC).toEpochMilli();
         assertThat(beskjed.getSynligFremTil(), is(expectedSynligFremTilAsUtcLong));
+        assertThat(beskjed.getEksternVarsling(), is(expectedEksternVarsling));
     }
 
     @Test

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveAvroTest.java
@@ -1,0 +1,38 @@
+package no.nav.brukernotifikasjon.schemas.builders;
+
+import no.nav.brukernotifikasjon.schemas.Oppgave;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OppgaveAvroTest {
+
+    private int expectedSikkerhetsnivaa = 4;
+    private boolean expectedEksternVarsling = false;
+
+    @Test
+    void skalSetteDefaultverdiForSikkerhetsnivaa() {
+        Oppgave oppgave = getOppgaveWithDefaultValues();
+        assertThat(oppgave.getSikkerhetsnivaa(), is(expectedSikkerhetsnivaa));
+    }
+
+    @Test
+    void skalSetteDefaultverdiForEksternVarsling() {
+        Oppgave oppgave = getOppgaveWithDefaultValues();
+        assertThat(oppgave.getEksternVarsling(), is(expectedEksternVarsling));
+    }
+
+    private Oppgave getOppgaveWithDefaultValues() {
+        return Oppgave.newBuilder()
+                .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
+                .setFodselsnummer("12345678901")
+                .setGrupperingsId("3456789123456")
+                .setTekst("Du må sende nytt meldekort")
+                .setLink("https://gyldig.url")
+                .build();
+    }
+}

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveBuilderTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveBuilderTest.java
@@ -26,6 +26,7 @@ class OppgaveBuilderTest {
     private URL expectedLink;
     private String expectedTekst;
     private LocalDateTime expectedTidspunkt;
+    private Boolean eksternVarsling;
 
     @BeforeAll
     void setUp() throws MalformedURLException {
@@ -35,6 +36,7 @@ class OppgaveBuilderTest {
         expectedLink = new URL("https://gyldig.url");
         expectedTekst = "Du må sende nytt meldekort";
         expectedTidspunkt = LocalDateTime.now();
+        eksternVarsling = false;
     }
 
     @Test
@@ -49,6 +51,7 @@ class OppgaveBuilderTest {
         assertThat(oppgave.getTekst(), is(expectedTekst));
         long expectedTidspunktAsUtcLong = expectedTidspunkt.toInstant(ZoneOffset.UTC).toEpochMilli();
         assertThat(oppgave.getTidspunkt(), is(expectedTidspunktAsUtcLong));
+        assertThat(oppgave.getEksternVarsling(), is(eksternVarsling));
     }
 
     @Test

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/StatusoppdateringAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/StatusoppdateringAvroTest.java
@@ -1,5 +1,6 @@
 package no.nav.brukernotifikasjon.schemas.builders;
 
+import no.nav.brukernotifikasjon.schemas.Beskjed;
 import no.nav.brukernotifikasjon.schemas.Statusoppdatering;
 import no.nav.brukernotifikasjon.schemas.builders.domain.StatusGlobal;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,14 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StatusoppdateringAvroTest {
+
+    private int expectedSikkerhetsnivaa = 4;
+
+    @Test
+    void skalSetteDefaultverdiForSikkerhetsnivaa() {
+        Statusoppdatering statusoppdatering = getStatusoppdateringWithDefaultValues();
+        assertThat(statusoppdatering.getSikkerhetsnivaa(), is(expectedSikkerhetsnivaa));
+    }
 
     @Test
     void skalSetteNullSomDefaultverdiForStatusIntern() {

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/StatusoppdateringAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/StatusoppdateringAvroTest.java
@@ -1,0 +1,32 @@
+package no.nav.brukernotifikasjon.schemas.builders;
+
+import no.nav.brukernotifikasjon.schemas.Statusoppdatering;
+import no.nav.brukernotifikasjon.schemas.builders.domain.StatusGlobal;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StatusoppdateringAvroTest {
+
+    @Test
+    void skalSetteNullSomDefaultverdiForStatusIntern() {
+        Statusoppdatering statusoppdatering = getStatusoppdateringWithDefaultValues();
+        assertThat(statusoppdatering.getStatusIntern(), is(nullValue()));
+    }
+
+    private Statusoppdatering getStatusoppdateringWithDefaultValues() {
+        return Statusoppdatering.newBuilder()
+                .setTidspunkt(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC))
+                .setGrupperingsId("3456789123456")
+                .setLink("https://gyldig.url")
+                .setStatusGlobal(StatusGlobal.UNDER_BEHANDLING.toString())
+                .setSakstema("FP")
+                .setFodselsnummer("12345678901")
+                .build();
+    }
+}


### PR DESCRIPTION
Jeg mener vi nå bør merge ekstern-varsling til master, og igjen ta master av schemas i bruk i våre apper. Ekstern varsling i prod er slått av vha feature-toggling i Vault. 