### PR TITLE
Legger til støtte for ekstern varsling for Innboks-eventer.

### DIFF
--- a/src/main/avro/innboks.avsc
+++ b/src/main/avro/innboks.avsc
@@ -20,6 +20,19 @@
             "name": "sikkerhetsnivaa",
             "type": "int",
             "default": 4
+        },
+        {
+            "name": "eksternVarsling",
+            "type": "boolean",
+            "default": false
+        },
+        {
+            "name": "prefererteKanaler",
+            "type": {
+                "type": "array",
+                "items": "string"
+            },
+            "default": []
         }
     ]
 }

--- a/src/main/avro/legacy/innboksLegacy.avsc
+++ b/src/main/avro/legacy/innboksLegacy.avsc
@@ -28,6 +28,19 @@
             "name": "sikkerhetsnivaa",
             "type": "int",
             "default": 4
+        },
+        {
+            "name": "eksternVarsling",
+            "type": "boolean",
+            "default": false
+        },
+        {
+            "name": "prefererteKanaler",
+            "type": {
+                "type": "array",
+                "items": "string"
+            },
+            "default": []
         }
     ]
 }

--- a/src/main/java/no/nav/brukernotifikasjon/schemas/builders/InnboksBuilder.java
+++ b/src/main/java/no/nav/brukernotifikasjon/schemas/builders/InnboksBuilder.java
@@ -2,10 +2,13 @@ package no.nav.brukernotifikasjon.schemas.builders;
 
 import no.nav.brukernotifikasjon.schemas.Innboks;
 import no.nav.brukernotifikasjon.schemas.builders.domain.Eventtype;
+import no.nav.brukernotifikasjon.schemas.builders.domain.PreferertKanal;
 import no.nav.brukernotifikasjon.schemas.builders.util.ValidationUtil;
 
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public class InnboksBuilder {
 
@@ -13,6 +16,8 @@ public class InnboksBuilder {
     private String tekst;
     private URL link;
     private Integer sikkerhetsnivaa;
+    private Boolean eksternVarsling = false;
+    private List<PreferertKanal> prefererteKanaler;
 
     public InnboksBuilder withTidspunkt(LocalDateTime tidspunkt) {
         this.tidspunkt = tidspunkt;
@@ -34,12 +39,26 @@ public class InnboksBuilder {
         return this;
     }
 
+    public InnboksBuilder withEksternVarsling(Boolean eksternVarsling) {
+        this.eksternVarsling = eksternVarsling;
+        return this;
+    }
+
+    public InnboksBuilder withPrefererteKanaler(PreferertKanal... prefererteKanaler) {
+        if(prefererteKanaler != null) {
+            this.prefererteKanaler = Arrays.asList(prefererteKanaler);
+        }
+        return this;
+    }
+
     public Innboks build() {
         return new Innboks(
                 ValidationUtil.localDateTimeToUtcTimestamp(tidspunkt, "tidspunkt", ValidationUtil.IS_REQUIRED_TIDSPUNKT),
                 ValidationUtil.validateNonNullFieldMaxLength(tekst, "tekst", ValidationUtil.MAX_LENGTH_TEXT_INNBOKS),
                 ValidationUtil.validateLinkAndConvertToString(link, "link", ValidationUtil.MAX_LENGTH_LINK, ValidationUtil.isLinkRequired(Eventtype.INNBOKS)),
-                ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa)
+                ValidationUtil.validateSikkerhetsnivaa(sikkerhetsnivaa),
+                eksternVarsling,
+                ValidationUtil.validatePrefererteKanaler(eksternVarsling, prefererteKanaler)
         );
     }
 }

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/BeskjedAvroTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,6 +16,7 @@ public class BeskjedAvroTest {
 
     private int expectedSikkerhetsnivaa = 4;
     private boolean expectedEksternVarsling = false;
+    private List<String> expectedPrefererteKanaler = emptyList();
 
     @Test
     void skalSetteDefaultverdiForSikkerhetsnivaa() {
@@ -25,6 +28,12 @@ public class BeskjedAvroTest {
     void skalSetteDefaultverdiForEksternVarsling() {
         Beskjed beskjed = getBeskjedWithDefaultValues();
         assertThat(beskjed.getEksternVarsling(), is(expectedEksternVarsling));
+    }
+
+    @Test
+    void skalSetteDefaultVerdiForPrefererteKanaler() {
+        Beskjed beskjed = getBeskjedWithDefaultValues();
+        assertThat(beskjed.getPrefererteKanaler(), is(expectedPrefererteKanaler));
     }
 
     @Test

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/InnboksAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/InnboksAvroTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -13,11 +15,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class InnboksAvroTest {
 
     private int expectedSikkerhetsnivaa = 4;
+    private boolean expectedEksternVarsling = false;
+    private List<String> expectedPrefererteKanaler = emptyList();
 
     @Test
     void skalSetteDefaultverdiForSikkerhetsnivaa() {
         Innboks innboks = getInnboksWithDefaultValues();
         assertThat(innboks.getSikkerhetsnivaa(), is(expectedSikkerhetsnivaa));
+    }
+
+    @Test
+    void skalSetteDefaultverdiForEksternVarsling() {
+        Innboks innboks = getInnboksWithDefaultValues();
+        assertThat(innboks.getEksternVarsling(), is(expectedEksternVarsling));
+    }
+
+    @Test
+    void skalSetteDefaultVerdiForPrefererteKanaler() {
+        Innboks innboks = getInnboksWithDefaultValues();
+        assertThat(innboks.getPrefererteKanaler(), is(expectedPrefererteKanaler));
     }
 
     private Innboks getInnboksWithDefaultValues() {

--- a/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveAvroTest.java
+++ b/src/test/java/no/nav/brukernotifikasjon/schemas/builders/OppgaveAvroTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -13,6 +15,7 @@ public class OppgaveAvroTest {
 
     private int expectedSikkerhetsnivaa = 4;
     private boolean expectedEksternVarsling = false;
+    private List<String> expectedPrefererteKanaler = emptyList();
 
     @Test
     void skalSetteDefaultverdiForSikkerhetsnivaa() {
@@ -24,6 +27,12 @@ public class OppgaveAvroTest {
     void skalSetteDefaultverdiForEksternVarsling() {
         Oppgave oppgave = getOppgaveWithDefaultValues();
         assertThat(oppgave.getEksternVarsling(), is(expectedEksternVarsling));
+    }
+
+    @Test
+    void skalSetteDefaultVerdiForPrefererteKanaler() {
+        Oppgave oppgave = getOppgaveWithDefaultValues();
+        assertThat(oppgave.getPrefererteKanaler(), is(expectedPrefererteKanaler));
     }
 
     private Oppgave getOppgaveWithDefaultValues() {


### PR DESCRIPTION
Tenker dette blir versjon 2.1.0? Eller tenker vi 2.0.1?

Tenker det mest ryddige blir i tillegg å branche ut fra der versjon 1.0.0 ble laget, og lage versjon 1.1.0 (evt. 1.0.1) med ekstern varsling for Innboks derfra.

Skal i tillegg legge det til i schemas-internal.