### PR TITLE
Flytter feilrespons hit fra internal repo.

### DIFF
--- a/src/main/avro/feilrespons.avsc
+++ b/src/main/avro/feilrespons.avsc
@@ -1,0 +1,20 @@
+{
+    "type": "record",
+    "namespace": "no.nav.brukernotifikasjon.schemas.output",
+    "name": "Feilrespons",
+    "fields": [
+        {
+            "name": "tidspunkt",
+            "type": "long",
+            "logicalType": "timestamp-millis"
+        },
+        {
+            "name": "begrunnelse",
+            "type": "string"
+        },
+        {
+            "name": "feilmelding",
+            "type": "string"
+        }
+    ]
+}

--- a/src/main/avro/nokkelFeilrespons.avsc
+++ b/src/main/avro/nokkelFeilrespons.avsc
@@ -1,0 +1,27 @@
+{
+    "type": "record",
+    "namespace": "no.nav.brukernotifikasjon.schemas.output",
+    "name": "NokkelFeilrespons",
+    "fields": [
+        {
+            "name": "eventId",
+            "type": "string"
+        },
+        {
+            "name": "brukernotifikasjonstype",
+            "type": "string"
+        },
+        {
+            "name": "namespace",
+            "type": "string"
+        },
+        {
+            "name": "appnavn",
+            "type": "string"
+        },
+        {
+            "name": "systembruker",
+            "type": "string"
+        }
+    ]
+}

--- a/src/main/java/no/nav/brukernotifikasjon/schemas/output/domain/FeilresponsBegrunnelse.java
+++ b/src/main/java/no/nav/brukernotifikasjon/schemas/output/domain/FeilresponsBegrunnelse.java
@@ -1,0 +1,5 @@
+package no.nav.brukernotifikasjon.schemas.output.domain;
+
+public enum FeilresponsBegrunnelse {
+    VALIDERINGSFEIL, DUPLIKAT, UKJENT
+}


### PR DESCRIPTION
Feilrespons flytter hit slik at produsenter har tilgang til dem. 

De havner i pakke `..schemas.output` for å speile eventenes `..schemas.input`.