### PR TITLE
Bumper avro fra 1.9.1 til 1.9.2 etter anbefaling fra snyk.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>8</java.version>
 
-        <avro.version>1.9.1</avro.version>
+        <avro.version>1.9.2</avro.version>
         <hamcrest.version>2.2</hamcrest.version>
         <junit.version>5.4.1</junit.version>
 


### PR DESCRIPTION
Liten bump for å fikse svakhet i transitiv dependency. Unnlater å behandle andre issues fra snyk ettersom de ikke er relevante for dette repoet.