### PR TITLE
Uten timestamp millis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>8</java.version>
 
-        <avro.version>1.9.2</avro.version>
+        <avro.version>1.11.0</avro.version>
         <hamcrest.version>2.2</hamcrest.version>
         <junit.version>5.4.1</junit.version>
 

--- a/src/main/avro/beskjedInput.avsc
+++ b/src/main/avro/beskjedInput.avsc
@@ -5,13 +5,11 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         },
         {
             "name": "synligFremTil",
             "type": ["null", "long"],
-            "logicalType": "timestamp-millis",
             "default": null
         },
         {

--- a/src/main/avro/doneInput.avsc
+++ b/src/main/avro/doneInput.avsc
@@ -5,8 +5,7 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         }
     ]
 }

--- a/src/main/avro/feilrespons.avsc
+++ b/src/main/avro/feilrespons.avsc
@@ -5,8 +5,7 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         },
         {
             "name": "begrunnelse",

--- a/src/main/avro/innboksInput.avsc
+++ b/src/main/avro/innboksInput.avsc
@@ -5,8 +5,7 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         },
         {
             "name": "tekst",

--- a/src/main/avro/oppgaveInput.avsc
+++ b/src/main/avro/oppgaveInput.avsc
@@ -5,13 +5,11 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         },
         {
             "name": "synligFremTil",
             "type": ["null", "long"],
-            "logicalType": "timestamp-millis",
             "default": null
         },
         {

--- a/src/main/avro/statusoppdateringInput.avsc
+++ b/src/main/avro/statusoppdateringInput.avsc
@@ -5,8 +5,7 @@
     "fields": [
         {
             "name": "tidspunkt",
-            "type": "long",
-            "logicalType": "timestamp-millis"
+            "type": "long"
         },
         {
             "name": "link",


### PR DESCRIPTION
Fjerner `"logicalType": "timestamp-millis"` fra alle tidsfelt, ettersom disse var formatert feil og har alltid vært ignorert. Dersom man fikser denne feilen vil man brekke kompatibilitet med eldre versjoner, så vi beholder typen "Long" på feltet.

Bumper også avro til 1.11.0.